### PR TITLE
Added config capability for custom policy.json

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -415,4 +415,9 @@ options:
     description: |
       A comma-separated list of nagios servicegroups.
       If left empty, the nagios_context will be used as the servicegroup
-
+  policy-override:
+    type: string
+    default: None
+    description: |
+      Base64 encoded policy.json template to override the default policy.json
+      Use at your own risk.

--- a/hooks/keystone_context.py
+++ b/hooks/keystone_context.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+import binascii
 import hashlib
 import os
 
@@ -37,6 +39,7 @@ from charmhelpers.core.hookenv import (
     log,
     leader_get,
     DEBUG,
+    ERROR,
     INFO,
 )
 
@@ -264,6 +267,14 @@ class KeystoneContext(context.OSContextGenerator):
         ctxt['admin_endpoint'] = endpoint_url(
             resolve_address(ADMIN),
             api_port('keystone-admin')).replace('v2.0', '')
+
+        if config('policy-override'):
+            ctxt['policy_override'] = True
+            try:
+                ctxt['custom_policy'] = b64decode(config('policy-override'))
+            except binascii.Error as e:
+                log('Could not decode policy.json override', level=ERROR)
+                raise e
 
         return ctxt
 

--- a/templates/ocata/policy.json
+++ b/templates/ocata/policy.json
@@ -1,4 +1,6 @@
-{% if api_version == 3 -%}
+{% if policy_override -%}
+{{ custom_policy }}
+{% else api_version == 3 -%}
 {
     "admin_required": "role:{{ admin_role }}",
     "cloud_admin": "rule:admin_required and (is_admin_project:True or domain_id:{{ admin_domain_id }} or project_id:{{ service_tenant_id }})",


### PR DESCRIPTION
Adds a config option for a custom policy.json, which accepts a policy file in the form of a base64 encoded string. When this config option is set it will insert the custom policy into the policy.json template, overriding the rest of the template. Unsetting the config option will render the template with its default behavior in the likely event someone shoots themselves in the foot.